### PR TITLE
Fix/statement upload duplicates

### DIFF
--- a/backend/app/Http/Controllers/TransactionUploadController.php
+++ b/backend/app/Http/Controllers/TransactionUploadController.php
@@ -22,11 +22,14 @@ class TransactionUploadController extends Controller
         // Calculate file hash to prevent duplicates
         $hash = md5_file($localPath);
 
-        // Check for duplicate upload
-        if (PdfUpload::where('hash', $hash)->exists()) {
+        // Check for duplicate upload for the current user only
+        if (PdfUpload::where('hash', $hash)
+            ->where('user_id', auth()->id())
+            ->exists()
+        ) {
             Storage::delete($path);
             return response()->json([
-                'message' => 'This statement has already been uploaded',
+                'message' => 'You have already uploaded this statement',
                 'error' => 'duplicate_statement'
             ], 400);
         }

--- a/backend/database/migrations/2025_03_26_205421_modify_pdf_uploads_hash_constraint.php
+++ b/backend/database/migrations/2025_03_26_205421_modify_pdf_uploads_hash_constraint.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pdf_uploads', function (Blueprint $table) {
+            // Drop the existing unique constraint on hash
+            $table->dropUnique(['hash']);
+
+            // Add a new composite unique constraint on hash and user_id
+            $table->unique(['hash', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pdf_uploads', function (Blueprint $table) {
+            // Drop the composite unique constraint
+            $table->dropUnique(['hash', 'user_id']);
+
+            // Restore the original unique constraint on hash
+            $table->unique(['hash']);
+        });
+    }
+};


### PR DESCRIPTION
# Fix Statement Upload Duplicate Handling

## Changes
- Modified duplicate check to be user-specific instead of global
- Added migration to create composite unique constraint on [hash, user_id]
- Updated error message to be more specific to the user

## Testing
- [ ] Upload a statement as User A
- [ ] Try to upload the same statement as User A (should fail)
- [ ] Upload the same statement as User B (should succeed)